### PR TITLE
Fix 'make install': include file directory creation was broken.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ install-headers:
 	$(INSTALL) -d $(DESTDIR)$(includedir)/tip
 #       Install headers
 	for h in $(HDRS) ; do \
-	  $(INSTALL) -m 644 $$h $(DESTDIR)$(includedir)/$$h ; \
+	  $(INSTALL) -D -m 644 $$h $(DESTDIR)$(includedir)/$$h ; \
 	done
 
 install-lib: $(BUILD_DIR)/release/lib/$(TIP_SLIB) $(BUILD_DIR)/dynamic/lib/$(TIP_DLIB).$(SOMAJOR).$(SOMINOR)$(SORELEASE)


### PR DESCRIPTION
The Makefile uses 'install' to install header files in a directory
hierarchy, but was not creating the parent directories ahead a time,
causing 'make install' to fail.
